### PR TITLE
Compatibility with custom order statuses

### DIFF
--- a/classes/Inc/Helpers.php
+++ b/classes/Inc/Helpers.php
@@ -530,13 +530,11 @@ final class Helpers {
 			] );
 
 			$format = implode(', ', array_fill(0, count($order_status), '%s'));
+
 			$orders_query = $wpdb->prepare("
-    			SELECT
-					ID
-				FROM
-					$wpdb->posts
-    			$date_where
-    				AND post_type = 'shop_order' AND post_status IN ($format)
+    			SELECT ID FROM $wpdb->posts  
+				$date_where
+				AND post_type = 'shop_order' AND post_status IN ($format)
 			", $order_status );
 
 			$query_columns              = $query_joins = [];

--- a/classes/Inc/Helpers.php
+++ b/classes/Inc/Helpers.php
@@ -524,11 +524,20 @@ final class Helpers {
 				$date_where .= $wpdb->prepare( ' AND post_date_gmt <= %s', $date_end );
 			}
 
-			$orders_query = "
-				SELECT ID FROM $wpdb->posts  
-				$date_where
-				AND post_type = 'shop_order' AND post_status IN ('wc-processing', 'wc-completed')				  
-			";
+			$order_status = (array) apply_filters( 'atum/get_sold_last_days/orders_status', [
+    			'wc-processing',
+    			'wc-completed',
+			] );
+
+			$format = implode(', ', array_fill(0, count($order_status), '%s'));
+			$orders_query = $wpdb->prepare("
+    			SELECT
+					ID
+				FROM
+					$wpdb->posts
+    			$date_where
+    				AND post_type = 'shop_order' AND post_status IN ($format)
+			", $order_status );
 
 			$query_columns              = $query_joins = [];
 			$use_lookup_table           = FALSE;


### PR DESCRIPTION
Fixes https://forum.stockmanagementlabs.com/d/1437-compatibility-with-custom-order-statuses/2

Allows filtering of the default statuses so the reports can include those statuses.

Proposed filters
```
// autm reports append custom statuses
add_filter( 'atum/get_sold_last_days/orders_status', array($this, 'add_custom_statuses_to_atum'));
add_filter( 'atum/dashboard/promo_sales_widget/order_status', array($this, 'add_custom_statuses_to_atum'));
add_filter( 'atum/dashboard/orders_widget/order_status', array($this, 'add_custom_statuses_to_atum'));
add_filter( 'atum/api/dashboard_orders/order_status', array($this, 'add_custom_statuses_to_atum'));
add_filter( 'atum/api/dashboard_promo_sales/order_status', array($this, 'add_custom_statuses_to_atum'));
add_filter( 'atum/dashboard/statistics_widget/promo_sales/order_status', array($this, 'add_custom_statuses_to_atum'));
add_filter( 'atum/dashboard/statistics_widget/orders/order_status', array($this, 'add_custom_statuses_to_atum'));
add_filter( 'atum/dashboard/orders_widget/order_status', array($this, 'add_custom_statuses_to_atum'));
```