### PR TITLE
URL decode product variations' title

### DIFF
--- a/classes/Components/AtumListTables/AtumListTable.php
+++ b/classes/Components/AtumListTables/AtumListTable.php
@@ -908,7 +908,7 @@ abstract class AtumListTable extends \WP_List_Table {
 			$attributes = $this->list_item->get_attributes();
 
 			if ( ! empty( $attributes ) ) {
-				$title = ucfirst( implode( ' ', $attributes ) );
+				$title = rawurldecode( ucfirst( implode( ' ', $attributes ) ) );
 			}
 
 			// Get the variable product ID to get the right link.


### PR DESCRIPTION
In non-English languages, product variations' title are encoded. User's have no way of knowing which variation is which. Decoding the title, helps users to know which variation they are working with.