### PR TITLE
Skip all WP-CLI logic on non-WP-CLI requests.

### DIFF
--- a/classes/Inc/Main.php
+++ b/classes/Inc/Main.php
@@ -254,7 +254,7 @@ class Main {
 		CheckOrderPrices::get_instance();
 		AtumNotifications::get_instance();
 
-		if ( class_exists( '\WP_CLI', FALSE ) ) {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			AtumCli::get_instance();
 		}
 


### PR DESCRIPTION
Per [this issue on the WP plugin support forums](https://wordpress.org/support/topic/breaks-on-bedrock-install-with-wp-cli-wp-cli-bundle-dependency/) and [this related issue opened on the WP-CLI repository](https://github.com/wp-cli/wp-cli/issues/5635#issuecomment-1243022798), improve the check for the WP-CLI command environment, removing the need for a variety of checks downstream, like [this one](https://github.com/StockManagementLabs/atum-stock-manager-for-woocommerce/blob/v1.9.21/classes/Cli/AtumCli.php#L42) (though this PR does not remove any such checks).