### PR TITLE
Improvement: Mark as WordPress plugin for Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
 	"license": "Copyrighted",
 	"minimum-stability": "dev",
 	"prefer-stable": true,
+	"type": "wordpress-plugin",
 	"config": {
 		"preferred-install": "dist"
 	},


### PR DESCRIPTION
Currently, it's impossible to install this plugin directly through Composer, as it ends up in the vendor folder. With this change, it should be possible to do a `stock-management-labs/atum-stock-manager-for-woocommerce` and put it in the correct folders.