### PR TITLE
fix: handle variable products missing get_out_stock_threshold

### DIFF
--- a/classes/Inc/Helpers.php
+++ b/classes/Inc/Helpers.php
@@ -2179,6 +2179,16 @@ final class Helpers {
 			$product = wc_get_product( $the_product );
 			Globals::disable_atum_product_data_models();
 
+			// If the returned product is not an ATUM product (e.g. returned from WooCommerce's
+			// ProductCache), instantiate the correct ATUM class directly.
+			if ( $product instanceof \WC_Product && ! self::is_atum_product( $product ) ) {
+				$atum_class = self::get_atum_product_class( $product->get_type() );
+
+				if ( $atum_class && class_exists( $atum_class ) && $atum_class !== get_class( $product ) ) {
+					$product = new $atum_class( $product->get_id() );
+				}
+			}
+
 			if ( $product instanceof \WC_Product && $use_cache ) {
 				AtumCache::set_cache( $cache_key, $product );
 			}

--- a/classes/MetaBoxes/ProductDataMetaBoxes.php
+++ b/classes/MetaBoxes/ProductDataMetaBoxes.php
@@ -258,7 +258,7 @@ class ProductDataMetaBoxes {
 
 		$product_id          = empty( $variation ) ? $post->ID : $variation->ID;
 		$product             = Helpers::get_atum_product( $product_id );
-		$out_stock_threshold = $product->get_out_stock_threshold();
+		$out_stock_threshold = is_callable( array( $product, 'get_out_stock_threshold' ) ) ? $product->get_out_stock_threshold() : NULL;
 		$product_type        = empty( $variation ) ? $product->get_type() : '';
 
 		$out_stock_threshold_field_name = empty( $variation ) ? $meta_key : "variation{$meta_key}[$loop]";
@@ -300,7 +300,7 @@ class ProductDataMetaBoxes {
 		$out_stock_threshold = $this->is_variation ? $_POST[ 'variation' . Globals::OUT_STOCK_THRESHOLD_KEY ][ $this->loop ] : $_POST[ Globals::OUT_STOCK_THRESHOLD_KEY ];
 
 		// Force product validate and save to rebuild stock_status (probably _out_stock_threshold has been disabled for this product).
-		if ( (float) $this->product->get_out_stock_threshold() !== (float) $out_stock_threshold ) {
+		if ( is_callable( array( $this->product, 'get_out_stock_threshold' ) ) && (float) $this->product->get_out_stock_threshold() !== (float) $out_stock_threshold ) {
 			Helpers::force_rebuild_stock_status( $this->product );
 		}
 


### PR DESCRIPTION
When WooCommerce's ProductCache returns a cached WC_Product_Variable instance, Helpers::get_atum_product() may return a plain WooCommerce product instead of ATUM's AtumProductVariable class. Since get_out_stock_threshold() is only defined in AtumProductTrait (not in WC_Product or WC_Product_Variable), this causes a fatal error on the product edit screen.

- Fall back to direct ATUM class instantiation in get_atum_product() when the returned product isn't an ATUM product
- Add is_callable() guards in ProductDataMetaBoxes for defense-in-depth